### PR TITLE
Remove calls to del self.fields['all_subevents']

### DIFF
--- a/pretix_cliques/views.py
+++ b/pretix_cliques/views.py
@@ -373,7 +373,6 @@ class RaffleForm(forms.Form):
             self.fields['subevent'].widget.choices = self.fields['subevent'].choices
         else:
             del self.fields['subevent']
-            del self.fields['all_subevents']
 
 
 class RejectForm(forms.Form):
@@ -403,7 +402,6 @@ class RejectForm(forms.Form):
             self.fields['subevent'].widget.choices = self.fields['subevent'].choices
         else:
             del self.fields['subevent']
-            del self.fields['all_subevents']
 
 
 class RaffleView(EventPermissionRequiredMixin, AsyncAction, FormView):


### PR DESCRIPTION
Hi @raphaelm, this seems to work out, even though it didn't undergo serious QA.
Searching for `all_subevents` leads to no other result, so it should be dead code, unless some string concatenation is done.